### PR TITLE
Fixed run as related parsing errors.

### DIFF
--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -150,8 +150,8 @@ class Sudoers(object):
                 # tmp["command"] = match.group(2)
                 tmp_command = match.group(2)
             else:
-                # Else, just treat this like a normal command
-                tmp_data["run_as"] = runas
+                # Else, just treat this like a normal command (only root can be impersonated)
+                tmp_data["run_as"] = ['root']
                 # tmp["command"] = command
                 tmp_command = command
 

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -73,7 +73,7 @@ class Sudoers(object):
         :rtype: tuple
         """
         # We need to keep all line spacing, so use the original line with the index stripped
-        kvline = re.sub(r"^%s " % alias_key, "", line)
+        kvline = re.sub(r"^%s\s*" % alias_key, "", line)
 
         # Split out the alias key/value
         keyval = kvline.split("=")

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -109,7 +109,9 @@ class Sudoers(object):
         data = []
 
         # runas and tags are running collectors as they are inherited by later commands
-        runas = None
+        # runas starts as 'root' to account for any commands without an explicit run as list,
+        # since they can only appear at the start, before the first explicit run as list
+        runas = ['root']
         tags = None
 
         # split the commands along commas without splitting users/groups inside run as parenthesis
@@ -150,8 +152,8 @@ class Sudoers(object):
                 # tmp["command"] = match.group(2)
                 tmp_command = match.group(2)
             else:
-                # Else, just treat this like a normal command (only root can be impersonated)
-                tmp_data["run_as"] = ['root']
+                # Else, just treat this like a normal command
+                tmp_data["run_as"] = runas
                 # tmp["command"] = command
                 tmp_command = command
 

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -105,21 +105,46 @@ class Sudoers(object):
         :rtype: dict
         """
         # This is the regular expression to try to parse out each command per line if it has a run as
-        runas_re = re.compile(r"\s*\(([\w,?]*)\)\s*([\S\s]*)")
+        runas_re = re.compile(r"\s*\(([\w,?:]*)\)\s*([\S\s]*)")
         data = []
 
         # runas and tags are running collectors as they are inherited by later commands
         runas = None
         tags = None
 
-        cmds = commands.split(",")
+        # split the commands along commas without splitting users/groups inside run as parenthesis
+        # ex: "root ALL = (ALL, ALL) ALL" shouldn't be split along the comma in parenthesis
+        cmds = list()
+        in_parens = False
+        curr_string = ""
+        for char in commands:
+            if in_parens:
+                curr_string += char
+                if char == ')':
+                    in_parens = False
+            else:
+                if char == ',':
+                    cmds.append(curr_string)
+                    curr_string = ""
+                elif char == '(':
+                    in_parens = True
+                    curr_string += '('
+                else:
+                    curr_string += char
+        if curr_string != "":
+            #add the last command
+            cmds.append(curr_string)
+
         for command in cmds:
             tmp_data = {}
             tmp_command = None
             # See if we have parentheses (a "run as") in the current command
             match = runas_re.search(command)
             if match:
-                tmp_data["run_as"] = match.group(1).split(",")
+                # split along commas and colons to get users and groups
+                unfiltered_data = re.split(",|:", match.group(1))
+                # filter out empty string in the case of (: [groups])
+                tmp_data["run_as"] = list(filter(None, unfiltered_data))
                 # Keep track of the latest "run_as"
                 runas = tmp_data["run_as"]
                 # tmp["command"] = match.group(2)
@@ -183,8 +208,8 @@ class Sudoers(object):
         """
         defaults_re = re.compile(r"^Defaults")
 
-        # Trim unnecessary spaces (no spaces before/after commas and colons)
-        line = re.sub(r"\s*([,:])\s*", r"\g<1>", line)
+        # Trim unnecessary spaces (no spaces before/after commas, colons, and equals signs)
+        line = re.sub(r"\s*([,:=])\s*", r"\g<1>", line)
 
         pieces = line.split()
         if pieces[0] in self._alias_types:

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -105,7 +105,7 @@ class Sudoers(object):
         :rtype: dict
         """
         # This is the regular expression to try to parse out each command per line if it has a run as
-        runas_re = re.compile(r"\s*\(([\w,?:]*)\)\s*([\S\s]*)")
+        runas_re = re.compile(r"\s*\(([\w,!?:]*)\)\s*([\S\s]*)")
         data = []
 
         # runas and tags are running collectors as they are inherited by later commands


### PR DESCRIPTION
I noticed that rules with more complicated operator lists, like the following:
```
    root ALL=(ALL:ALL) ALL
    %sudo ALL=(root, admin : ALL) ALL
```
weren't being properly parsed out into the Sudoers class.

I also noticed that commands at the start of rules with no operator lists were given `None` as the 'run_as' entry in their dictionary, while the lack of an operator list implies that root is the only user that can be impersonated in that case. To fix this, I made the 'run_as' entry a list containing only `'root'`.

My initial fix broke the behavior when there were multiple commands using the same explicit run_as list. I've updated it to only set the 'run_as' entry to `'root'` for commands listed immediately after the equals sign, but before the first explicit run_as list. For example, in `bob ALL=[cmnd1], (ALL) [cmnd2], [cmnd3]` only `[cmnd1]` should have `'root'` applied as it's run_as list, not `[cmnd3]` (my initial fix didn't have this behavior, but the updated one does).

These changes should hopefully fix these behaviors without causing many issues.

I also allowed aliases with tabs or multiple spaces between the alias type and the alias name to be parsed properly by the `parse_alias` method.