### PR TITLE
add parsing of elements with quotes and 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This library provides a [Python][1] interface to the Linux sudoers file.  python
 
 This library parses a sudoers file into its component parts.  It's not 100% compliant with the EBNF format of the file (yet), but it's getting there.  Currently, the script parses out 6 distinct line types from the file:
 
-* Defaults (This is only a string currently.  Pieces of a Defaults setting are not parsed/separated.)
+* Defaults (List of dicts with these keys)
+  * scope  - if Defaults@xx, it's the @xxx part, None if none there.
+  * setting - the unparsed rest of the line.
 * Cmnd_Alias
 * Host_Alias
 * Runas_Alias
@@ -47,7 +49,8 @@ from pysudoers import Sudoers
 sobj = Sudoers(path="tmp/sudoers")
 
 for default in sobj.defaults:
-    print(default)
+    print(default.scope)
+    print(default.setting)
 
 for key in sobj.host_aliases:
     print(key)

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -237,7 +237,8 @@ class Sudoers(object):
 
         return rule
 
-    def parse_defaults(self, line):
+    @staticmethod
+    def parse_defaults(line):
         """Parse the defaults into component pieces.
             Defaults[@user] setting
             Returns a list of dicts.  dict has two components.

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -301,7 +301,9 @@ class Sudoers(object):
         """
         backslash_re = re.compile(r"\\$")
 
-        if hasattr(self._path, 'write'):
+        # if _path has the 'read' attribute, it's assumed to be a file handle
+        # otherwise, it's a name.
+        if hasattr(self._path, 'read'):
             sudo = self._path
         else:
             sudo = open(self._path, "r")

--- a/tests/test_sudoers.py
+++ b/tests/test_sudoers.py
@@ -137,8 +137,8 @@ class TestInit(TestSudoers):
         # Check internal values for defaults
         self.assertIn('scope', sudoobj._data["Defaults"][0])
         self.assertIn('setting', sudoobj._data["Defaults"][0])
-        self.assertEqual(sudoobj._data["Defaults"], [{'scope': None, 'setting': "!insults"}, 
-            {'scope': ':SOMEUSERS', 'setting': "!umask"}])
+        self.assertEqual(sudoobj._data["Defaults"], [{'scope': None, 'setting': "!insults"},
+                                                     {'scope': ':SOMEUSERS', 'setting': "!umask"}])
         # Check internal values for rules
         self.assertEqual(sudoobj._data["Rules"], self.test_correct_rules)
 

--- a/tests/test_sudoers.py
+++ b/tests/test_sudoers.py
@@ -135,7 +135,10 @@ class TestInit(TestSudoers):
         )
 
         # Check internal values for defaults
-        self.assertEqual(sudoobj._data["Defaults"], ["Defaults !insults", "Defaults:SOMEUSERS !umask"])
+        self.assertIn('scope', sudoobj._data["Defaults"][0])
+        self.assertIn('setting', sudoobj._data["Defaults"][0])
+        self.assertEqual(sudoobj._data["Defaults"], [{'scope': None, 'setting': "!insults"}, 
+            {'scope': ':SOMEUSERS', 'setting': "!umask"}])
         # Check internal values for rules
         self.assertEqual(sudoobj._data["Rules"], self.test_correct_rules)
 

--- a/tests/test_sudoers.py
+++ b/tests/test_sudoers.py
@@ -38,19 +38,23 @@ class TestSudoers(TestCase):
 
         self.test_correct_rules = [
             {"users": ["SOMEUSERS"], "hosts": ["SOMEHOSTS"], "commands": [
-                {"run_as": ["SOMERUNAS"], "tags": None, "command": "SOMECMND"},
-            ]},
+                {"run_as": ["SOMERUNAS"], "tags": None, "command": "SOMECMND"},],
+             "original": "SOMEUSERS SOMEHOSTS=(SOMERUNAS) SOMECMND",
+            },
             {"users": ["SOMEUSERS"], "hosts": ["ALL"], "commands": [
-                {"run_as": ["SOMERUNAS"], "tags": None, "command": "/path/to/something/else"},
-            ]},
+                {"run_as": ["SOMERUNAS"], "tags": None, "command": "/path/to/something/else"},],
+             "original": "SOMEUSERS ALL=(SOMERUNAS) /path/to/something/else"
+            },
             {"users": ["SOMEUSERS"], "hosts": ["SOMEHOSTS"], "commands": [
                 {"run_as": ["ALL"], "tags": ["NOPASSWD"], "command": "/path/to/something/else"},
-                {"run_as": ["ALL"], "tags": ["NOPASSWD"], "command": "/path/to/more"},
-            ]},
+                {"run_as": ["ALL"], "tags": ["NOPASSWD"], "command": "/path/to/more"},],
+             "original": "SOMEUSERS SOMEHOSTS=(ALL) NOPASSWD:/path/to/something/else,/path/to/more",
+            },
             {"users": ["randouser"], "hosts": ["SOMEHOSTS"], "commands": [
                 {"run_as": ["SOMERUNAS"], "tags": None, "command": "SOMECMND"},
-                {"run_as": ["root"], "tags": None, "command": "/path/to/more/things"},
-            ]}
+                {"run_as": ["root"], "tags": None, "command": "/path/to/more/things"},],
+             "original": "randouser SOMEHOSTS=(SOMERUNAS) SOMECMND,(root)/path/to/more/things",
+            }
         ]
 
         self.fake_path = "/path/to/sudoers"


### PR DESCRIPTION
I needed the module to be able to support elements in quotes.  Changed Defaults to include the decorations:

  "Defaults@Host_List  setting_value"  also supports (":User_List", "!Cmnd_List", ">Runas_List")

returns a list of dictionaries   [ {scope: '@Host_list', setting: setting_value'}, ...]
No parsing of setting_value

Supports "%name with spaces" in sudoers.  This is an Active Directory thing, sigh.