### PR TITLE
feat: Enhancement/Fix some rule parsing errors

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -49,7 +49,7 @@ function build() {
         labels+=( --label "$label" )
     done
 
-    "${SUDO[@]}" "$CONTAINER_APP" build --pull -t "$CONTAINER_IMAGE" "${labels[@]}" .
+    "${SUDO[@]}" "$CONTAINER_APP" build -f Containerfile --pull -t "$CONTAINER_IMAGE" "${labels[@]}" .
 }
 
 if [[ "$TERM" != 'dumb' ]]; then

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import ClassVar, Generator
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -79,8 +83,7 @@ class Sudoers:
     @classmethod
     def parse_alias(cls, alias_key: str, line: str) -> Generator[tuple, None, None]:
         """
-        Parse an alias line into its component parts,
-        a single statement can declare mutiple aliases.
+        Parse an alias line into its component parts, a single statement can declare mutiple aliases.
 
         :param str alias_key: The type of alias we are parsing
         :param str line: The line from sudoers
@@ -114,7 +117,7 @@ class Sudoers:
             yield (keyval[0], val_list)
 
     @staticmethod
-    def parse_commands(commands: str) -> list:  # pylint: disable-msg=too-many-locals
+    def parse_commands(commands: str) -> list:  # noqa:C901,PLR0912 pylint: disable-msg=too-many-locals
         """
         Parse all commands from a rule line.
 
@@ -288,7 +291,7 @@ class Sudoers:
                 errmsg = f"bad alias: {line}"
                 raise BadAliasExceptionError(errmsg)
 
-            for (key, members) in self.parse_alias(index, line):
+            for key, members in self.parse_alias(index, line):
                 if key in self._data[index]:
                     errmsg = f"duplicate alias: {line}"
                     raise DuplicateAliasExceptionError(errmsg)

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -79,12 +79,14 @@ class Sudoers:
     @classmethod
     def parse_alias(cls, alias_key: str, line: str) -> Generator[tuple, None, None]:
         """
-        Parse an alias line into its component parts.
+        Parse an alias line into its component parts,
+        a single statement can declare mutiple aliases.
 
         :param str alias_key: The type of alias we are parsing
         :param str line: The line from sudoers
 
-        :return: 0) the key for the alias and 1) the list of members of that alias
+        :return: A generator of the aliases declared in the statement,
+                 each entry is a tuple: 0) the key for the alias and 1) the list of members of that alias
         :rtype: Generator[tuple, None, None]
         """
         # We need to keep all line spacing, so use the original line with the index stripped

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -92,7 +92,9 @@ class Sudoers:
         # We need to keep all line spacing, so use the original line with the index stripped
         kvline = re.sub(rf"^{alias_key}\s*", "", line)
 
-        for sub_alias in re.split(r"[^\\|sha224|sha256|sha384|sha512]:", kvline):
+        # The : character is used to declare multiple aliases
+        # Do not split when it is escaped or preceded by a known statement
+        for sub_alias in re.split(r"(?<!\\)(?<!sha224|sha256|sha384|sha512):", kvline):
             # Split out the alias key/value
             keyval = cls.escaped_split(sub_alias, "=", maxsplit=1)
             if (len(keyval) != cls.MIN_LINE_PIECES) or (not keyval[1]):

--- a/pysudoers/__init__.py
+++ b/pysudoers/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Generator
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/data/correct.txt
+++ b/tests/data/correct.txt
@@ -26,5 +26,12 @@ SOMEUSERS SOMEHOSTS = (ALL) NOPASSWD: /path/to/something/else, /path/to/more
 
 randouser SOMEHOSTS=(SOMERUNAS) SOMECMND, (root)/path/to/more/things
 
+# The following examples are from https://www.man7.org/linux/man-pages/man5/sudoers.5.html
+
 ALL CDROM = NOPASSWD: /sbin/umount /CDROM,\
     /sbin/mount -o nosuid\,nodev /dev/cd0a /CDROM
+
+Host_Alias     SPARC = bigtime, eclipse, moet, anchor :\
+               SGI = grolsch, dandelion, black :\
+               ALPHA = widget, thalamus, foobar :\
+               HPPA = boa, nag, python

--- a/tests/data/correct.txt
+++ b/tests/data/correct.txt
@@ -25,3 +25,6 @@ SOMEUSERS ALL=(SOMERUNAS) /path/to/something/else
 SOMEUSERS SOMEHOSTS = (ALL) NOPASSWD: /path/to/something/else, /path/to/more
 
 randouser SOMEHOSTS=(SOMERUNAS) SOMECMND, (root)/path/to/more/things
+
+ALL CDROM = NOPASSWD: /sbin/umount /CDROM,\
+    /sbin/mount -o nosuid\,nodev /dev/cd0a /CDROM

--- a/tests/test_sudoers.py
+++ b/tests/test_sudoers.py
@@ -76,6 +76,21 @@ class TestSudoers(TestCase):
                     },
                 ],
             },
+            {
+                "users": ["ALL"],
+                "hosts": ["CDROM"],
+                "commands": [
+                    {
+                        "run_as": ["root"],
+                        "tags": ["NOPASSWD"],
+                        "command": "/sbin/umount /CDROM"},
+                    {
+                        "run_as": ["root"],
+                        "tags": ["NOPASSWD"],
+                        "command": "/sbin/mount -o nosuid,nodev /dev/cd0a /CDROM"
+                     },
+                ],
+            }
         ]
 
         self.fake_path = Path("/path/to/sudoers")

--- a/tests/test_sudoers.py
+++ b/tests/test_sudoers.py
@@ -150,6 +150,32 @@ class TestInit(TestSudoers):
         assert sudoobj._data["Cmnd_Alias"]["SOMECMND"] == ["/path/to/the/command"]
         assert "SOMEHOSTS" in sudoobj._data["Host_Alias"]
         assert sudoobj._data["Host_Alias"]["SOMEHOSTS"] == ["some-host1", "some-host2"]
+        # Check the values for multiples aliases in a single statement
+        assert "SPARC" in sudoobj._data["Host_Alias"]
+        assert sudoobj._data["Host_Alias"]["SPARC"] == [
+            "bigtime",
+            "eclipse",
+            "moet",
+            "anchor"
+        ]
+        assert "SGI" in sudoobj._data["Host_Alias"]
+        assert sudoobj._data["Host_Alias"]["SGI"] == [
+            "grolsch",
+            "dandelion",
+            "black"
+        ]
+        assert "ALPHA" in sudoobj._data["Host_Alias"]
+        assert sudoobj._data["Host_Alias"]["ALPHA"] == [
+            "widget",
+            "thalamus",
+            "foobar"
+        ]
+        assert "HPPA" in sudoobj._data["Host_Alias"]
+        assert sudoobj._data["Host_Alias"]["HPPA"] == [
+            "boa",
+            "nag",
+            "python"
+        ]
         assert "SOMERUNAS" in sudoobj._data["Runas_Alias"]
         assert sudoobj._data["Runas_Alias"]["SOMERUNAS"] == ["runuser"]
         assert "SOMEUSERS" in sudoobj._data["User_Alias"]
@@ -192,6 +218,31 @@ class TestProperties(TestSudoers):
         # Make sure the values match
         assert "SOMEHOSTS" in self.sudoobj.host_aliases
         assert self.sudoobj.host_aliases["SOMEHOSTS"] == ["some-host1", "some-host2"]
+        assert "SPARC" in self.sudoobj.host_aliases
+        assert self.sudoobj.host_aliases["SPARC"] == [
+            "bigtime",
+            "eclipse",
+            "moet",
+            "anchor"
+        ]
+        assert "SGI" in self.sudoobj.host_aliases
+        assert self.sudoobj.host_aliases["SGI"] == [
+            "grolsch",
+            "dandelion",
+            "black"
+        ]
+        assert "ALPHA" in self.sudoobj.host_aliases
+        assert self.sudoobj.host_aliases["ALPHA"] == [
+            "widget",
+            "thalamus",
+            "foobar"
+        ]
+        assert "HPPA" in self.sudoobj.host_aliases
+        assert self.sudoobj.host_aliases["HPPA"] == [
+            "boa",
+            "nag",
+            "python"
+        ]
 
     def test_rules(self) -> None:
         """Rules property returns the correct data."""


### PR DESCRIPTION
Hello,

First of all, thank you for providing this library

I was testing it on examples extracted from https://www.man7.org/linux/man-pages/man5/sudoers.5.html and I noticed some parsing errors. This pull request is an attempt to fix them with a couples of tweaks :
- update to `dev.sh` to support Docker, as I was getting an error, it is still compatible with Podman
- `parse_commands` doesn't split on escaped commas anymore
- `parse_alias` now returns a generator of aliases

Notes:
- I chose the split regex in `parse_alias` based on a quick review of the specs, it may not be sufficient
- I have yet to fix the parsing of the `bob             SPARC = (OP) ALL : SGI = (OP) ALL` line (return `SPARC=(OP)` as the host and the second part isn't processed)